### PR TITLE
Fix for Wild Arms [SCUS-94608] being incorrectly detected as PAL

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -401,7 +401,7 @@ int CheckCdrom() {
 		strcpy(CdromId, "SLUS99999");
 
 	if (Config.PsxAuto) { // autodetect system (pal or ntsc)
-		if (CdromId[2] == 'e' || CdromId[2] == 'E')
+		if ((CdromId[0] == 's' || CdromId[0] == 'S') && (CdromId[2] == 'e' || CdromId[2] == 'E'))
 			Config.PsxType = PSX_TYPE_PAL; // pal
 		else Config.PsxType = PSX_TYPE_NTSC; // ntsc
 


### PR DESCRIPTION
For some reason the CdromId of Wild Arms (US) is being incorrectly parsed as "EXESCUS94" when it should be "SCUS94608".
PCSX4ALL checks if the third character of the CdromId is an "E" to detect PAL games. Coincidentially, the third character of "EXESCUS94" is an "E". So PCSX4ALL is incorrectly detecting this NTSC game as PAL.
This fix makes it require that the first character is an "S" AND the third character is an "E" to be detected as PAL, so in the case of "EXESCUS94" it will be detected as NTSC.

According to psxdatacenter, 100% of the PS1 PAL games IDs are S?E?99999, so this fix should not break anything.